### PR TITLE
Fix default encoding for CFStringCreateWithCString

### DIFF
--- a/macoslib/CoreFoundation/CFString.rbbas
+++ b/macoslib/CoreFoundation/CFString.rbbas
@@ -34,9 +34,9 @@ Implements CFPropertyList
 		    if Encoding(s) <> nil then
 		      p = CFStringCreateWithCString(nil, s, Encoding(s).code)
 		    else
-		      const kCFStringEncodingInvalidId = &hffffffff
+		      const kCFStringEncodingASCII = &h0600
 		      
-		      p = CFStringCreateWithCString(nil, s, kCFStringEncodingInvalidId)
+		      p = CFStringCreateWithCString(nil, s, kCFStringEncodingASCII)
 		    end if
 		    
 		    self.Constructor(p, hasOwnership)


### PR DESCRIPTION
It turns out that kCFStringEncodingInvalidId isn't a valid encoding for creating a CFString. I replaced it with kCFStringEncodingASCII as a reasonable default encoding, which does work.
